### PR TITLE
Change the NAME in control script

### DIFF
--- a/script/control
+++ b/script/control
@@ -3,10 +3,9 @@
 APP_MODULE=app
 APP_START_CMD=start_with_dependencies
 APP_DIR=`pwd`
-NAME=`basename $APP_DIR`
+NAME=`basename $(git remote show -n origin | grep Fetch | cut -d: -f2-) | sed s/\.git//g`
 NODE_NAME=$NAME@`hostname`
 COOKIE="omnomnomnom"
-
 
 # Try to get the process Pid
 case `uname -s` in


### PR DESCRIPTION
When running multiple Erlang processes using the same control script to initiate them, some of them won't start due to duplicate node names.`
This commit fixes the duplicate node names by generating a unique NAME for the app based on the project's git repo
